### PR TITLE
backslash in get method

### DIFF
--- a/client/src/services/monstersService.js
+++ b/client/src/services/monstersService.js
@@ -2,7 +2,7 @@ import api from './api'
 
 export default {
     getAllMonsters () {
-        return api().get('monsters')
+        return api().get('monsters/')
     },
 
     getMonsters(page, perPage, sortField, sortOrder, searchText, cr) {


### PR DESCRIPTION
It appears a backslash was missing. Judging by the other get methods this is probably a typo.